### PR TITLE
Added unique serial numbers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ class IFTTTPlatform {
         accessory.name = s.name;
         accessory.model = 'IFTTT';
         accessory.manufacturer = 'IFTTT';
-        accessory.serialNumber = '<unknown>';
+        accessory.serialNumber = 'IFTTT-' + s.name;
         foundAccessories.push(accessory);
       }
     });


### PR DESCRIPTION
Added unique serial numbers for each accessory, which is helpful when using third-party tools that help to manage and backup/restore HomeKit setups. Used the same format as homebridge-dummy.